### PR TITLE
to reduce the verbosity of Maven

### DIFF
--- a/travis_build.sh
+++ b/travis_build.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
 set -ev
+
+# to reduce the verbosity of Maven (downloading log)
+# to avoid the Travis error
+# "The job exceeded the maximum log length, and has been terminated."
+MAVEN_ARGS="-B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
 	if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
 		echo "Build on MacOSX: Pull Request"
-		mvn -f org.example.parent/pom.xml clean verify -Pall
+		mvn $MAVEN_ARGS -f org.example.parent/pom.xml clean verify -Pall
 		# cd org.example.helloidea.parent && ./gradlew clean build
 	else
 		echo "Skipping build on MacOSX for standard commit"
@@ -12,6 +18,6 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
 	fi
 else
 	echo "Build on Linux"
-	mvn -f org.example.parent/pom.xml clean verify -Pall
+	mvn $MAVEN_ARGS -f org.example.parent/pom.xml clean verify -Pall
 	# cd org.example.helloidea.parent && ./gradlew clean build
 fi 


### PR DESCRIPTION
To avoid the Travis error
"The job exceeded the maximum log length, and has been terminated."